### PR TITLE
feat: 로컬 구동환경 세팅 with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 sui.log*
 
 .env
+*.env
 
 *.pem
 *.crt

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ run:
 	docker-compose up
 
 generate-ssl-cert:
-	if [ ! -f ./localhost.key ] || [ ! -f ./localhost.crt ]; then \
+	if [ ! -f ./nginx/localhost.key ] || [ ! -f ./nginx/localhost.crt ]; then \
   		echo "Generating SSL certificates..."; \
-		openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./localhost.key -out ./localhost.crt; \
+		openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./nginx/localhost.key -out ./nginx/localhost.crt; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+run:
+	make generate-ssl-cert
+	@echo "Running the application..."
+	docker-compose up
+
+generate-ssl-cert:
+	if [ ! -f ./localhost.key ] || [ ! -f ./localhost.crt ]; then \
+  		echo "Generating SSL certificates..."; \
+		openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./localhost.key -out ./localhost.crt; \
+	fi
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Enjoy <strong>Blackjack</strong> at ShallWeMove🔥!!
 [Player](#player-account-client) <br/>
 
 # Get Started
+
+## Local Development
+
+```bash
+make run
+```
+SSL Certificate files are required to run the server.
+`localhost.crt` and `localhost.key` will be automatically generated in the `nginx` directory.
+
 ## Connect Your Wallet
 ![play_1](https://github.com/ShallWeMove/SuiMove-Blackjack/assets/72509938/b432a14c-36ba-4883-9f28-092962f9a190)
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,12 @@
-FROM node:latest
+FROM node:alpine
 
 WORKDIR /app
 
-COPY backend/package*.json ./
+COPY package*.json ./
 RUN npm install
 
-ENV SSL_CERT_FILE ./localhost.crt
-ENV SSL_KEY_FILE ./localhost.key
+COPY . .
 
-COPY backend .
-
-EXPOSE 443
+EXPOSE 8080
 
 CMD ["npm", "start"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:latest
+
+WORKDIR /app
+
+COPY backend/package*.json ./
+RUN npm install
+
+ENV SSL_CERT_FILE ./localhost.crt
+ENV SSL_KEY_FILE ./localhost.key
+
+COPY backend .
+
+EXPOSE 443
+
+CMD ["npm", "start"]

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,15 +13,15 @@ import {
 } from "./moveCall";
 
 dotenv.config();
-const server = https.createServer({
-  cert: fs.readFileSync("/home/ptw/SuiMove-Blackjack/frontend/fullchain1.pem"), // 인증서 경로
-  key: fs.readFileSync("/home/ptw/SuiMove-Blackjack/frontend/privkey1.pem"), // 개인키 경로
-});
+// const server = https.createServer({
+//   cert: fs.readFileSync("/home/ptw/SuiMove-Blackjack/frontend/fullchain1.pem"), // 인증서 경로
+//   key: fs.readFileSync("/home/ptw/SuiMove-Blackjack/frontend/privkey1.pem"), // 개인키 경로
+// });
 
 const provider = getProvider(process.env.RPC_URL!);
 const dealer_signer = getSigner(process.env.DEALER_PRIVATE_KEY!, provider);
 
-const wss = new WebSocketServer({ server });
+const wss = new WebSocketServer({ port: 8080 });
 
 wss.on("connection", (ws: WebSocket) => {
   console.log("Client connected.");
@@ -60,4 +60,4 @@ wss.on("connection", (ws: WebSocket) => {
   });
 });
 
-server.listen(8080);
+// server.listen(8080);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,20 +2,32 @@ version: "3.8"
 services:
   frontend:
     build:
-      context: .
-      dockerfile: frontend/Dockerfile
+      context: frontend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: backend
+    volumes:
+      - ./backend:/app
+      - /app/node_modules
+    environment:
+      - RPC_URL=https://fullnode.testnet.sui.io:443
+    ports:
+      - "8080:8080"
+
+  nginx:
+    build:
+      context: nginx
     ports:
       - "80:80"
       - "443:443"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf
-      - ./localhost.crt:/etc/nginx/ssl/localhost.crt
-      - ./localhost.key:/etc/nginx/ssl/localhost.key
     depends_on:
+      - frontend
       - backend
-  backend:
-    build:
-      context: .
-      dockerfile: backend/Dockerfile
-    ports:
-      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+      - ./localhost.crt:/etc/nginx/ssl/localhost.crt
+      - ./localhost.key:/etc/nginx/ssl/localhost.key
+    depends_on:
+      - backend
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    ports:
+      - "8080:8080"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:latest as builder
+
+WORKDIR /app
+
+COPY frontend/package*.json ./
+RUN npm install
+
+COPY frontend .
+RUN npm run build
+
+FROM nginx:alpine
+
+#COPY ../nginx.conf /etc/nginx/nginx.conf
+
+COPY --from=builder /app/build /usr/share/nginx/html
+
+#COPY ../localhost.crt /etc/nginx/ssl/localhost.crt
+#COPY ../localhost.key /etc/nginx/ssl/localhost.key
+
+EXPOSE 80
+EXPOSE 443
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,23 +1,12 @@
-FROM node:latest as builder
+FROM node:alpine
 
 WORKDIR /app
 
-COPY frontend/package*.json ./
+COPY package*.json ./
 RUN npm install
 
-COPY frontend .
-RUN npm run build
+COPY . .
 
-FROM nginx:alpine
+EXPOSE 3000
 
-#COPY ../nginx.conf /etc/nginx/nginx.conf
-
-COPY --from=builder /app/build /usr/share/nginx/html
-
-#COPY ../localhost.crt /etc/nginx/ssl/localhost.crt
-#COPY ../localhost.key /etc/nginx/ssl/localhost.key
-
-EXPOSE 80
-EXPOSE 443
-
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["npm", "start"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "dev": "react-scripts start",
-    "start": "HTTPS=true SSL_CRT_FILE=./fullchain1.pem SSL_KEY_FILE=./privkey1.pem react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/frontend/src/components/BlackJack.tsx
+++ b/frontend/src/components/BlackJack.tsx
@@ -23,7 +23,7 @@ import useSound from "use-sound";
 import GameTableScore from "./GameTableScore";
 
 // Create a WebSocket connection
-const socket = new WebSocket("wss://shallwemove.xyz:8080");
+const socket = new WebSocket("ws://localhost/ws");
 
 // const BlackJack: React.FC = () => {
 const BlackJack = ({

--- a/frontend/src/components/GetFunctions.js
+++ b/frontend/src/components/GetFunctions.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import config from "../config.json";
 
-const socket = new WebSocket("wss://shallwemove.xyz:8080");
+const socket = new WebSocket("ws://localhost/ws");
 
 export async function getObject(object_id) {
   const response = await axios.post(config.TESTNET_ENDPOINT, {

--- a/frontend/src/components/SideBar.js
+++ b/frontend/src/components/SideBar.js
@@ -3,11 +3,8 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 export default function SideBar() {
-  //const [socket, setSocket] = useState(null);
-  const ws = new WebSocket("wss://35.200.66.115:8080");
-
   useEffect(() => {
-    const ws = new WebSocket("ws://localhost:8080");
+    const ws = new WebSocket("ws://localhost/ws");
 
     ws.onmessage = (event) => {
       toast(event.data.digest, { autoClose: 10000 });

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx
+
+COPY ./localhost.crt /etc/nginx/ssl/localhost.crt
+COPY ./localhost.key /etc/nginx/ssl/localhost.key
+
+COPY ./default.conf /etc/nginx/conf.d/default.conf

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,31 @@
+upstream frontend {
+    server frontend:3000;
+}
+
+upstream backend {
+    server backend:8080;
+}
+
+server {
+    listen 80;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+
+    ssl_certificate /etc/nginx/ssl/localhost.crt;
+    ssl_certificate_key /etc/nginx/ssl/localhost.key;
+
+    location / {
+        proxy_pass http://frontend;
+    }
+    location /ws {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+}


### PR DESCRIPTION
* 프론트엔드, 백엔드 모두 로컬에서 쉽게 작동시키면서 테스트할 수 있는 환경을 마련해요.
  * openssl로 SSL 인증서 발급 
  * Nginx 활용해서 HTTPS 통신
  * docker-compose로 쉽게 서버 실행
=> 결론적으로 `make run` 만 하면 로컬에서 HTTPS로 프론트/백 모두 실행돼요.